### PR TITLE
Fix ActiveCampaign webhook threading

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.1
+
+- Fixed `ac_webhook` sensor stuck with timeouts by enabling Flask app threading #3
+
 # 0.3.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ActiveCampaign Integration pack
+[![Build Status](https://circleci.com/gh/StackStorm-Exchange/stackstorm-activecampaign/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm-Exchange/stackstorm-activecampaign)
 
 API: http://www.activecampaign.com/api/overview.php
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,4 +4,4 @@ name: activecampaign
 author: DoriftoShoes
 description: 'Integration with ActiveCampaign'
 email: patrick@stackstorm.com
-version: 0.3.0
+version: 0.3.1

--- a/sensors/ac_webhook.py
+++ b/sensors/ac_webhook.py
@@ -45,7 +45,10 @@ class ActiveCampaignWebhook(Sensor):
             return json.dumps({"response": "triggerposted"})
 
     def run(self):
-        self.app.run(host=self.host, port=self.port, debug=True)
+        """
+        Start the Flask web app
+        """
+        self.app.run(host=self.host, port=self.port, debug=True, threaded=True)
 
     def cleanup(self):
         # This is called when the st2 system goes down.


### PR DESCRIPTION
Enabling threading option in Flask web app, allowing to process more than a couple of requests.

IDK how this even worked before, blocked/stucked with timeouts all the time.