### PR TITLE
Don't throw on AC errors, pass to client to handle.

### DIFF
--- a/actions/run.py
+++ b/actions/run.py
@@ -24,16 +24,24 @@ class ActiveCampaignAction(Action):
             headers=headers, data=params
         )
 
-        results = response.json()
-        if results['result_code'] is not 1:
+        self.logger.debug("status: %s body: %s" % (
+            response.status_code, response.text))
+
+        if response.status_code is not 200:
             failure_reason = (
                 'Failed to perform action. status code: %s; response body: %s' % (
                     response.status_code,
-                    response.json()
+                    response.text
                 )
             )
             self.logger.exception(failure_reason)
             raise Exception(failure_reason)
+
+        results = response.json()
+        if results['result_code'] is not 1:
+            # Error message will also appears in results. Let client handle it.
+            self.logger.error("Active Campaign returned error: %s" % (
+                results['result_message']))
 
         return results
 

--- a/etc/ac_api_gen.py
+++ b/etc/ac_api_gen.py
@@ -1,7 +1,7 @@
 import yaml
 import re
 import urllib2
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup  # pylint: disable=import-error
 
 import time
 


### PR DESCRIPTION
In many cases Active Campaign API returns 200,
but the body contains error. Those domain errors should be
handled by the client: throwing exception makes it impossible.

Example: contact_add: if contact is already created, it is
no harm to try and create it again. AC returns 200 and says "The email santa@claus.net is in the system already, please edit that contact instead" 

The client can check [result_code] and implement the logic to handle "the client already created",
or just ignore it.